### PR TITLE
Fix an import error with newer versions of FeinCMS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # incuna-feincms changelog
 
+## v2.0.5
+
+* Support newer versions of FeinCMS, where `feincms_page_tags` has been moved.
+
 ## v2.0.4
 
 * Import `FilterExpression` from `django.template.base`.

--- a/incunafein/templatetags/incunafein_tags.py
+++ b/incunafein/templatetags/incunafein_tags.py
@@ -1,7 +1,10 @@
 from django import template
 from feincms.module.medialibrary.models import Category
 from feincms.module.page.models import Page, PageManager
-from feincms.module.page.templatetags.feincms_page_tags import is_equal_or_parent_of
+try:
+    from feincms.templatetags.feincms_page_tags import is_equal_or_parent_of
+except ImportError:
+    from feincms.module.page.templatetags.feincms_page_tags import is_equal_or_parent_of
 
 register = template.Library()
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ setup(
     name = "incuna-feincms",
     packages = find_packages(),
     include_package_data=True,
-    version = '2.0.4',
+    version = '2.0.5',
     description = "Provides enhancements to FeinCMS.",
     author = "Incuna Ltd",
     author_email = "admin@incuna.com",


### PR DESCRIPTION
Causes a hard crash in any page whose template uses `{% load incunafein_tags %}`. Not good.

@incuna/backend review/merge please?